### PR TITLE
cannot overfill facilities with animals

### DIFF
--- a/src/Actions/ChooseGrazingField.cs
+++ b/src/Actions/ChooseGrazingField.cs
@@ -16,7 +16,7 @@ namespace Trestlebridge.Actions
             {
                 Console.WriteLine($"{i + 1}. Grazing Field");
             }
-            // Why are they using a JS style for loop
+            // To show the number of grazing fields
 
             Console.WriteLine();
 

--- a/src/Models/Facilities/ChickenHouse.cs
+++ b/src/Models/Facilities/ChickenHouse.cs
@@ -20,10 +20,16 @@ namespace Trestlebridge.Models.Facilities {
 
         public string Message { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
-        public void AddResource (IMeatProducing animal)
+        public void AddResource (IMeatProducing animal){
+        if(this.Capacity > this._animals.Count)
         {
              _animals.Add(animal);
-        }
+        }else{
+
+    Console.WriteLine("that Chicken Coop is full");
+    Console.WriteLine("Press enter to return to main menu");
+    Console.ReadLine();
+        }}
 
         public void AddResource (List<IMeatProducing> animals)
         {

--- a/src/Models/Facilities/DuckHouse.cs
+++ b/src/Models/Facilities/DuckHouse.cs
@@ -20,10 +20,16 @@ namespace Trestlebridge.Models.Facilities {
 
         public string Message { get;}
 
-        public void AddResource (IMeatProducing animal)
+        public void AddResource (IMeatProducing animal){
+        if(this.Capacity > this._animals.Count)
         {
-            _animals.Add(animal);
-        }
+             _animals.Add(animal);
+        }else{
+
+    Console.WriteLine("that duckhouse is full");
+    Console.WriteLine("Press enter to return to main menu");
+    Console.ReadLine();
+        }}
 
         public void AddResource (List<IMeatProducing> animals)
         {

--- a/src/Models/Facilities/GrazingField.cs
+++ b/src/Models/Facilities/GrazingField.cs
@@ -18,12 +18,16 @@ namespace Trestlebridge.Models.Facilities {
             }
         }
 
-        public void AddResource (IGrazing animal)
+        public void AddResource (IGrazing animal){
+        if(this.Capacity > this._animals.Count)
         {
-            // TODO: implement this...
-            _animals.Add(animal);
-           Console.WriteLine($"The {animal} is in the field");
-        }
+             _animals.Add(animal);
+        }else{
+
+    Console.WriteLine("that grazingfield is full");
+    Console.WriteLine("Press enter to return to main menu");
+    Console.ReadLine();
+        }}
 
         public void AddResource (List<IGrazing> animals)
         {

--- a/src/Models/Farm.cs
+++ b/src/Models/Farm.cs
@@ -65,10 +65,8 @@ namespace Trestlebridge.Models
             GrazingFields.ForEach(gf => report.Append(gf));
             PlowedFields.ForEach(pf => report.Append(pf));
             NaturalFields.ForEach(nf=> report.Append(nf));
-
             ChickenHouses.ForEach(ch => report.Append(ch));
             DuckHouses.ForEach(dh => report.Append(dh));
-
             return report.ToString();
         }
 


### PR DESCRIPTION
# Description

Now you cannot fill an animals facility beyond capacity, should be about the same code for seed fields.

## Related Ticket(s)
8

## Steps to Test
1. Choose a facility to test.(example: chickenhouse, duckhouse, grazingfield)Set _capacity to a low number before you start you're terminal(so you don't have to purchase many animals)
2. buy the facility your testing
3. purchase animals until a message appears that says the facility is full.

# Checklist:
- [ no] I have commented my code, particularly in hard-to-understand areas
- [yes ] I have made corresponding changes to the documentation
- [ yes] My changes generate no new errors
